### PR TITLE
Updated inference by OpenVINO API 2.0

### DIFF
--- a/src/inference/inference_async_mode.py
+++ b/src/inference/inference_async_mode.py
@@ -6,7 +6,7 @@ import logging as log
 import postprocessing_data as pp
 from time import time
 from io_adapter import io_adapter
-from transformer import transformer
+from transformer import openvino_transformer
 from io_model_wrapper import openvino_io_model_wrapper
 from openvino.runtime import AsyncInferQueue
 
@@ -134,7 +134,7 @@ def main():
     args = build_parser().parse_args()
     try:
         model_wrapper = openvino_io_model_wrapper()
-        data_transformer = transformer()
+        data_transformer = openvino_transformer()
         io = io_adapter.get_io_adapter(args, model_wrapper, data_transformer)
         core = utils.create_core(
             args.extension,

--- a/src/inference/inference_async_mode.py
+++ b/src/inference/inference_async_mode.py
@@ -8,7 +8,7 @@ from time import time
 from io_adapter import io_adapter
 from transformer import openvino_transformer
 from io_model_wrapper import openvino_io_model_wrapper
-from openvino.runtime import AsyncInferQueue
+from openvino.runtime import AsyncInferQueue  # pylint: disable=E0401
 
 
 def build_parser():

--- a/src/inference/inference_async_mode.py
+++ b/src/inference/inference_async_mode.py
@@ -5,10 +5,10 @@ import numpy as np
 import logging as log
 import postprocessing_data as pp
 from time import time
-from copy import copy
 from io_adapter import io_adapter
 from transformer import transformer
 from io_model_wrapper import openvino_io_model_wrapper
+from openvino.runtime import AsyncInferQueue
 
 
 def build_parser():
@@ -29,8 +29,8 @@ def build_parser():
         default=None, type=int, dest='requests'
     )
     parser.add_argument('-b', '--batch_size', help='Size of the processed pack', default=1, type=int, dest='batch_size')
-    parser.add_argument('-l', '--extension', help='Path to MKLDNN (CPU, MYRIAD) custom layers', type=str, default=None, dest='extension')
-    parser.add_argument('-c', '--cldnn_config', help='Path to CLDNN config.', type=str, default=None, dest='cldnn_config')
+    parser.add_argument('-l', '--extension', help='Path to INTEL_CPU (CPU, MYRIAD) custom layers', type=str, default=None, dest='extension')
+    parser.add_argument('-c', '--intel_gpu_config', help='Path to INTEL_GPU config.', type=str, default=None, dest='intel_gpu_config')
     parser.add_argument(
         '-d', '--device',
         help='Specify the target'
@@ -86,30 +86,27 @@ def build_parser():
     return parser
 
 
-def infer_async(exec_net, number_iter, get_slice):
+def infer_async(compiled_model, number_iter, num_request, get_slice):
     result = None
-    requests = exec_net.requests
-    for i in range(len(requests)):
-        utils.set_input_to_blobs(requests[i], get_slice(i))
-    iteration = len(requests)
+    infer_queue = AsyncInferQueue(compiled_model, num_request)
+    iteration = 0
     inference_time = time()
-    for request in requests:
-        request.async_infer()
-    while iteration < number_iter:
-        idle_id = exec_net.get_idle_request_id()
+    while iteration < max(number_iter, num_request):
+        idle_id = infer_queue.get_idle_request_id()
         if idle_id < 0:
-            exec_net.wait(num_requests=1)
-            idle_id = exec_net.get_idle_request_id()
-        utils.set_input_to_blobs(requests[idle_id], get_slice(iteration))
-        requests[idle_id].async_infer()
+            infer_queue.wait(num_requests=1)
+            idle_id = infer_queue.get_idle_request_id()
+        utils.set_input_to_blobs(infer_queue[idle_id], get_slice(iteration))
+        infer_queue.start_async()
         iteration += 1
-    exec_net.wait()
+    infer_queue.wait_all()
     inference_time = time() - inference_time
     if number_iter == 1:
-        list = [copy(request.outputs) for request in requests]
-        result = dict.fromkeys(list[0].keys(), None)
+        request_results = [utils.get_request_result(request) for request in infer_queue]
+        output_names = request_results[0].keys()
+        result = dict.fromkeys(output_names, None)
         for key in result:
-            result[key] = np.concatenate([array[key] for array in list], axis=0)
+            result[key] = np.concatenate([result[key] for result in request_results], axis=0)
     return result, inference_time
 
 
@@ -139,9 +136,9 @@ def main():
         model_wrapper = openvino_io_model_wrapper()
         data_transformer = transformer()
         io = io_adapter.get_io_adapter(args, model_wrapper, data_transformer)
-        iecore = utils.create_ie_core(
+        core = utils.create_core(
             args.extension,
-            args.cldnn_config,
+            args.intel_gpu_config,
             args.device,
             args.nthreads,
             args.nstreams,
@@ -149,27 +146,29 @@ def main():
             'async',
             log
         )
-        net = utils.create_network(iecore, args.model_xml, args.model_bin, log)
-        utils.configure_network(iecore, net, args.device, args.default_device, args.affinity)
-        input_shapes = utils.get_input_shape(model_wrapper, net)
+        model = utils.create_model(core, args.model_xml, args.model_bin, log)
+        utils.configure_model(core, model, args.device, args.default_device, args.affinity)
+        input_shapes = utils.get_input_shape(model_wrapper, model)
         for layer in input_shapes:
             log.info('Shape for input layer {0}: {1}'.format(layer, input_shapes[layer]))
-        utils.reshape_input(net, args.batch_size)
+        utils.reshape_input(model, args.batch_size)
         log.info('Prepare input data')
-        io.prepare_input(net, args.input)
+        io.prepare_input(model, args.input)
         log.info('Create executable network')
-        exec_net = utils.load_network(iecore, net, args.device, args.priority, args.requests)
-        log.info('Starting inference ({} iterations) with {} requests on {}'.format(args.number_iter, len(exec_net.requests), args.device))
-        result, time = infer_async(exec_net, args.number_iter, io.get_slice_input)
+        compiled_model = utils.compile_model(core, model, args.device, args.priority)
+        log.info('Starting inference ({} iterations) with {} requests on {}'.format(args.number_iter,
+                                                                                    args.requests,
+                                                                                    args.device))
+        result, time = infer_async(compiled_model, args.number_iter, args.requests, io.get_slice_input)
         average_time, fps = process_result(time, args.batch_size, args.number_iter)
         if not args.raw_output:
             io.process_output(result, log)
             result_output(average_time, fps, log)
         else:
             raw_result_output(average_time, fps)
-        del net
-        del exec_net
-        del iecore
+        del model
+        del compiled_model
+        del core
     except Exception as ex:
         print('ERROR! : {0}'.format(str(ex)))
         sys.exit(1)

--- a/src/inference/inference_sync_mode.py
+++ b/src/inference/inference_sync_mode.py
@@ -4,7 +4,7 @@ import argparse
 import logging as log
 import postprocessing_data as pp
 from io_adapter import io_adapter
-from transformer import transformer
+from transformer import openvino_transformer
 from io_model_wrapper import openvino_io_model_wrapper
 
 
@@ -112,7 +112,7 @@ def main():
     args = build_argparser().parse_args()
     try:
         model_wrapper = openvino_io_model_wrapper()
-        data_transformer = transformer()
+        data_transformer = openvino_transformer()
         io = io_adapter.get_io_adapter(args, model_wrapper, data_transformer)
         core = utils.create_core(
             args.extension,

--- a/src/inference/inference_sync_mode.py
+++ b/src/inference/inference_sync_mode.py
@@ -20,8 +20,8 @@ def build_argparser():
         required=True, type=str, nargs='+', dest='input'
     )
     parser.add_argument('-b', '--batch_size', help='Size of the processed pack', default=1, type=int, dest='batch_size')
-    parser.add_argument('-l', '--extension', help='Path to MKLDNN (CPU, MYRIAD) custom layers', type=str, default=None, dest='extension')
-    parser.add_argument('-c', '--cldnn_config', help='Path to CLDNN config.', type=str, default=None, dest='cldnn_config')
+    parser.add_argument('-l', '--extension', help='Path to INTEL_CPU (CPU, MYRIAD) custom layers', type=str, default=None, dest='extension')
+    parser.add_argument('-c', '--intel_gpu_config', help='Path to INTEL_GPU config.', type=str, default=None, dest='intel_gpu_config')
     parser.add_argument(
         '-d', '--device',
         help='Specify the target'
@@ -33,7 +33,7 @@ def build_argparser():
         default='CPU', type=str, dest='device'
     )
     parser.add_argument('--default_device', help='Default device for heterogeneous inference', choices=['CPU', 'GPU', 'MYRIAD', 'FGPA'], default=None, type=str, dest='default_device')
-    parser.add_argument('--dump', help='Dump information about the model exectution', type=bool, default=False, dest='dump')
+    parser.add_argument('--dump', help='Dump information about the model execution', type=bool, default=False, dest='dump')
     parser.add_argument(
         '-p', '--priority',
         help='Priority for multi-device inference in descending order.'
@@ -71,8 +71,8 @@ def build_argparser():
     return parser
 
 
-def infer_sync(exec_net, number_iter, get_slice):
-    request = exec_net.requests[0]
+def infer_sync(compiled_model, number_iter, get_slice):
+    request = compiled_model.create_infer_request()
     result = None
     time_infer = []
     for i in range(number_iter):
@@ -80,7 +80,7 @@ def infer_sync(exec_net, number_iter, get_slice):
         request.infer()
         time_infer.append(request.latency/1000)
     if number_iter == 1:
-        result = request.outputs
+        result = utils.get_request_result(request)
     return result, time_infer
 
 
@@ -114,9 +114,9 @@ def main():
         model_wrapper = openvino_io_model_wrapper()
         data_transformer = transformer()
         io = io_adapter.get_io_adapter(args, model_wrapper, data_transformer)
-        iecore = utils.create_ie_core(
+        core = utils.create_core(
             args.extension,
-            args.cldnn_config,
+            args.intel_gpu_config,
             args.device,
             args.nthreads,
             None,
@@ -124,27 +124,27 @@ def main():
             'sync',
             log
         )
-        net = utils.create_network(iecore, args.model_xml, args.model_bin, log)
-        utils.configure_network(iecore, net, args.device, args.default_device, args.affinity)
-        input_shapes = utils.get_input_shape(model_wrapper, net)
+        model = utils.create_model(core, args.model_xml, args.model_bin, log)
+        utils.configure_model(core, model, args.device, args.default_device, args.affinity)
+        input_shapes = utils.get_input_shape(model_wrapper, model)
         for layer in input_shapes:
             log.info('Shape for input layer {0}: {1}'.format(layer, input_shapes[layer]))
-        utils.reshape_input(net, args.batch_size)
+        utils.reshape_input(model, args.batch_size)
         log.info('Prepare input data')
-        io.prepare_input(net, args.input)
+        io.prepare_input(model, args.input)
         log.info('Create executable network')
-        exec_net = utils.load_network(iecore, net, args.device, args.priority, 1)
+        compiled_model = utils.compile_model(core, model, args.device, args.priority)
         log.info('Starting inference ({} iterations) on {}'.format(args.number_iter, args.device))
-        result, time = infer_sync(exec_net, args.number_iter, io.get_slice_input)
+        result, time = infer_sync(compiled_model, args.number_iter, io.get_slice_input)
         average_time, latency, fps = process_result(time, args.batch_size, args.mininfer)
         if not args.raw_output:
             io.process_output(result, log)
             result_output(average_time, fps, latency, log)
         else:
             raw_result_output(average_time, fps, latency)
-        del net
-        del exec_net
-        del iecore
+        del model
+        del compiled_model
+        del core
     except Exception as ex:
         print('ERROR! : {0}'.format(str(ex)))
         sys.exit(1)

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -78,13 +78,14 @@ class io_adapter(metaclass=abc.ABCMeta):
                     value = value.split(',')
                     value = self.__create_list_images(value)
                     shape = self._io_model_wrapper.get_input_layer_shape(model, key)
+                    element_type = self._io_model_wrapper.get_input_layer_dtype(model, key)
                     value, shapes = self.__convert_images(shape, value)
-                    transformed_value = self._transformer.transform_images(value)
+                    transformed_value = self._transformer.transform_images(value, element_type)
                 self._input.update({key: value})
                 self._original_shapes.update({key: shapes})
                 self._transformed_input.update({key: transformed_value})
         else:
-            input_blob = shape = self._io_model_wrapper.get_input_layer_names(model)[0]
+            input_blob = self._io_model_wrapper.get_input_layer_names(model)[0]
             file_format = input[0].split('.')[-1]
             if 'csv' == file_format:
                 value = self.__parse_tensors(input[0])
@@ -93,8 +94,9 @@ class io_adapter(metaclass=abc.ABCMeta):
             else:
                 value = self.__create_list_images(input)
                 shape = self._io_model_wrapper.get_input_layer_shape(model, input_blob)
+                element_type = self._io_model_wrapper.get_input_layer_dtype(model, input_blob)
                 value, shapes = self.__convert_images(shape, value)
-                transformed_value = self._transformer.transform_images(value)
+                transformed_value = self._transformer.transform_images(value, element_type)
             self._input.update({input_blob: value})
             self._original_shapes.update({input_blob: shapes})
             self._transformed_input.update({input_blob: transformed_value})

--- a/src/inference/io_model_wrapper.py
+++ b/src/inference/io_model_wrapper.py
@@ -29,7 +29,7 @@ class openvino_io_model_wrapper(io_model_wrapper):
         return None
 
     def get_input_layer_dtype(self, model, node_name):
-        from openvino.runtime.utils.types import get_dtype
+        from openvino.runtime.utils.types import get_dtype  # pylint: disable=E0401
         for input in model.inputs:
             if node_name == input.get_any_name():
                 return get_dtype(input.get_element_type())

--- a/src/inference/transformer.py
+++ b/src/inference/transformer.py
@@ -6,11 +6,11 @@ class transformer:
         return image
 
     def get_shape_in_chw_order(self, shape):
-        return shape[1:]
+        return shape[1], shape[2], shape[3]
 
-    def transform_images(self, images):
+    def transform_images(self, images, element_type):
         b, c, h, w = images.shape
-        transformed_images = np.zeros(shape=(b, c, h, w))
+        transformed_images = np.zeros(shape=(b, c, h, w), dtype=element_type)
         for i in range(b):
             transformed_images[i] = self._transform(images[i])
         return transformed_images
@@ -75,10 +75,10 @@ class tensorflow_transformer(transformer):
         self.__set_input_scale(transformed_image)
         return transformed_image
 
-    def transform_images(self, images):
+    def transform_images(self, images, element_type):
         images = images.transpose(0, 2, 3, 1)
         b, h, w, c = images.shape
-        transformed_images = np.zeros(shape=(b, h, w, c))
+        transformed_images = np.zeros(shape=(b, h, w, c), dtype=element_type)
         for i in range(b):
             transformed_images[i] = self._transform(images[i])
         return transformed_images

--- a/src/inference/transformer.py
+++ b/src/inference/transformer.py
@@ -6,13 +6,35 @@ class transformer:
         return image
 
     def get_shape_in_chw_order(self, shape):
-        return shape[1], shape[2], shape[3]
+        return shape[1:]
 
-    def transform_images(self, images, element_type):
-        b, c, h, w = images.shape
-        transformed_images = np.zeros(shape=(b, c, h, w), dtype=element_type)
+    def transform_images(self, images, shape, element_type):
+        b = shape[0]
+        transformed_images = np.zeros(shape=shape, dtype=element_type)
         for i in range(b):
             transformed_images[i] = self._transform(images[i])
+        return transformed_images
+
+
+class openvino_transformer(transformer):
+    def _transform(self, image, shape):
+        if self.__is_nhwc(shape):
+            return image
+        return image.transpose(2, 0, 1)
+
+    def __is_nhwc(self, shape):
+        return (len(shape) in [3, 4]) and (shape[len(shape) - 1] in [1, 3])
+
+    def get_shape_in_chw_order(self, shape):
+        if self.__is_nhwc(shape):
+            return shape[3], shape[1], shape[2]
+        return shape[1], shape[2], shape[3]
+
+    def transform_images(self, images, shape, element_type):
+        b = shape[0]
+        transformed_images = np.zeros(shape=shape, dtype=element_type)
+        for i in range(b):
+            transformed_images[i] = self._transform(images[i], shape)
         return transformed_images
 
 
@@ -38,6 +60,7 @@ class intelcaffe_transformer(transformer):
 
     def _transform(self, image):
         transformed_image = np.copy(image)
+        transformed_image = transformed_image.transpose(1, 2, 0)
         self.__set_channel_swap(transformed_image)
         self.__set_mean(transformed_image)
         self.__set_input_scale(transformed_image)
@@ -75,10 +98,9 @@ class tensorflow_transformer(transformer):
         self.__set_input_scale(transformed_image)
         return transformed_image
 
-    def transform_images(self, images, element_type):
-        images = images.transpose(0, 2, 3, 1)
-        b, h, w, c = images.shape
-        transformed_images = np.zeros(shape=(b, h, w, c), dtype=element_type)
+    def transform_images(self, images, shape, element_type):
+        b = shape[0]
+        transformed_images = np.zeros(shape=shape, dtype=element_type)
         for i in range(b):
             transformed_images[i] = self._transform(images[i])
         return transformed_images

--- a/src/inference/utils.py
+++ b/src/inference/utils.py
@@ -123,7 +123,10 @@ def get_input_shape(io_model_wrapper, model):
     layer_shapes = dict()
     layer_names = io_model_wrapper.get_input_layer_names(model)
     for input_layer in layer_names:
-        shape = str(io_model_wrapper.get_input_layer_shape(model, input_layer))
+        shape = ''
+        for dim in io_model_wrapper.get_input_layer_shape(model, input_layer):
+            shape += '{0}x'.format(dim)
+        shape = shape[:-1]
         layer_shapes.update({input_layer: shape})
     return layer_shapes
 

--- a/src/inference/utils.py
+++ b/src/inference/utils.py
@@ -1,48 +1,50 @@
-from openvino.inference_engine import IECore  # pylint: disable=E0401
+from copy import copy
+from openvino.runtime import Core, Tensor, PartialShape  # pylint: disable=E0401
 
 
-def create_network(iecore, model_xml, model_bin, log):
-    log.info('Loading network files:\n\t {0}\n\t {1}'.format(
+def create_model(core, model_xml, model_bin, log):
+    log.info('Loading model files:\n\t {0}\n\t {1}'.format(
         model_xml, model_bin))
-    network = iecore.read_network(model=model_xml, weights=model_bin)
-    return network
+    model = core.read_model(model=model_xml, weights=model_bin)
+    return model
 
 
 def parse_affinity(affinity_file):
     affinity = {}
     with open(affinity_file, 'r') as f:
         for line in f:
-            layer, device = line.strip().split(' ')
-            affinity.update({layer: device})
+            node, device = line.strip().split(' ')
+            affinity.update({node: device})
     return affinity
 
 
-def configure_network(ie, net, device, default_device, affinity_file):
+def configure_model(core, model, device, default_device, affinity_file):
     if 'HETERO' not in device:
         return
-    layers = net.layers
+    nodes = model.get_ops()
     if affinity_file:
         if not default_device:
             raise ValueError('--default_device is required parameter for heterogeneous inference')
         affinity = parse_affinity(affinity_file)
-        for layer in layers:
-            if layer in affinity.keys():
-                layers[layer].affinity = affinity[layer]
+        for node in nodes:
+            if node.get_friendly_name() in affinity.keys():
+                node.get_rt_info()["affinity"] = affinity[node.get_friendly_name()]
             else:
-                layers[layer].affinity = default_device
+                node.get_rt_info()["affinity"] = default_device
     else:
-        layers_map = ie.query_network(network=net, device_name=device)
-        for layer, device in layers_map.items():
-            layers[layer].affinity = device
+        supported_ops = core.query_model(model=model, device_name=device)
+        for node in nodes:
+            affinity = supported_ops[node.get_friendly_name()]
+            node.get_rt_info()["affinity"] = affinity
 
 
-def add_extension(iecore, path_to_extension, path_to_cldnn_config, device, log):
+def add_extension(core, path_to_extension, path_to_intel_gpu_config, device, log):
     if path_to_extension:
         if 'GPU' in device:
-            iecore.set_config({'CONFIG_FILE': path_to_cldnn_config}, 'GPU')
+            core.set_property('GPU', {'CONFIG_FILE': path_to_intel_gpu_config})
             log.info('GPU extensions is loaded {}'.format(path_to_extension))
         if 'CPU' in device or 'MYRIAD' in device:
-            iecore.add_extension(path_to_extension, 'CPU')
+            core.add_extension(path_to_extension, 'CPU')
             log.info('CPU extensions is loaded {}'.format(path_to_extension))
 
 
@@ -71,81 +73,89 @@ def parse_value_per_device(device_list, values):
     return result
 
 
-def set_config(iecore, devices, nthreads, nstreams, dump, mode):
+def set_property(core, devices, nthreads, nstreams, dump, mode):
     device_list = parse_devices(devices)
     streams_dict = parse_value_per_device(device_list, nstreams)
     for device in device_list:
         if device == 'CPU':
             if nthreads:
-                iecore.set_config({'CPU_THREADS_NUM': str(nthreads)}, 'CPU')
+                core.set_property('CPU', {'CPU_THREADS_NUM': str(nthreads)})
             if 'MULTI' in devices and 'GPU' in devices:
-                iecore.set_config({'CPU_BIND_THREAD': 'NO'}, 'CPU')
+                core.set_property({'CPU_BIND_THREAD': 'NO'}, 'CPU')
             if mode == 'async':
                 cpu_throughput = {'CPU_THROUGHPUT_STREAMS': 'CPU_THROUGHPUT_AUTO'}
                 if device in streams_dict.keys() and streams_dict[device]:
                     cpu_throughput['CPU_THROUGHPUT_STREAMS'] = streams_dict['CPU']
-                iecore.set_config(cpu_throughput, 'CPU')
+                core.set_property('CPU', cpu_throughput)
         if device == 'GPU':
             if 'MULTI' in devices and 'СPU' in devices:
-                iecore.set_config({'CLDNN_PLUGIN_THROTTLE': '1'}, 'GPU')
+                core.set_property('GPU', {'GPU_QUEUE_THROTTLE': '1'})
             if mode == 'async':
                 gpu_throughput = {'GPU_THROUGHPUT_STREAMS': 'GPU_THROUGHPUT_AUTO'}
                 if device in streams_dict.keys() and streams_dict[device]:
                     gpu_throughput['GPU_THROUGHPUT_STREAMS'] = streams_dict['GPU']
-                iecore.set_config(gpu_throughput, 'GPU')
+                core.set_property('GPU', gpu_throughput)
     if dump:
         if 'HETERO' in devices:
-            iecore.set_config({'HETERO_DUMP_GRAPH_DOT': 'YES'}, 'HETERO')
+            core.set_property('HETERO', {'OPENVINO_HETERO_VISUALIZE': 'YES'})
         elif not('MULTI' in devices):
-            iecore.set_config({'DUMP_EXEC_GRAPH_AS_DOT': 'exec_graph'}, devices)
+            core.set_property(devices, {'DUMP_EXEC_GRAPH_AS_DOT': 'exec_graph'})
 
 
-def create_ie_core(path_to_extension, path_to_cldnn_config, device, nthreads, nstreams,
-                   dump, mode, log):
+def create_core(path_to_extension, path_to_intel_gpu_config, device, nthreads, nstreams,
+                dump, mode, log):
     log.info('Inference Engine initialization')
-    ie = IECore()
-    add_extension(ie, path_to_extension, path_to_cldnn_config, device, log)
-    set_config(ie, device, nthreads, nstreams, dump, mode)
-    return ie
+    core = Core()
+    add_extension(core, path_to_extension, path_to_intel_gpu_config, device, log)
+    set_property(core, device, nthreads, nstreams, dump, mode)
+    return core
 
 
-def load_network(iecore, network, device, multi_priority, requests):
-    config = {}
+def compile_model(core, model, device, multi_priority):
+    properties = {}
     if 'MULTI' in device and multi_priority:
-        config.update({'MULTI_DEVICE_PRIORITIES': multi_priority})
-    exec_net = iecore.load_network(
-        network=network,
-        device_name=device,
-        num_requests=(requests or 0),
-        config=config
-    )
-    return exec_net
+        properties.update({'MULTI_DEVICE_PRIORITIES': multi_priority})
+    compiled_model = core.compile_model(model, device, properties)
+    return compiled_model
 
 
 def get_input_shape(io_model_wrapper, model):
     layer_shapes = dict()
     layer_names = io_model_wrapper.get_input_layer_names(model)
     for input_layer in layer_names:
-        shape = ''
-        for dem in io_model_wrapper.get_input_layer_shape(model, input_layer):
-            shape += '{0}x'.format(dem)
-        shape = shape[:-1]
+        shape = str(io_model_wrapper.get_input_layer_shape(model, input_layer))
         layer_shapes.update({input_layer: shape})
     return layer_shapes
 
 
-def reshape_input(net, batch_size):
+def reshape_input(model, batch_size):
     new_shapes = {}
-    for layer in net.inputs:
-        shape = net.inputs[layer].shape
+    for input in model.inputs:
+        shape = input.get_partial_shape()
         shape[0] = batch_size
-        new_shapes.update({layer: shape})
-    net.reshape(new_shapes)
+        new_shapes.update({input.get_any_name(): shape})
+    model.reshape(new_shapes)
 
 
 def set_input_to_blobs(request, input):
-    blobs = request.inputs
-    for layer, tensor in input.items():
-        if layer not in blobs.keys():
-            raise ValueError("No input layer with name {}".format(layer))
-        blobs[layer][:] = tensor
+    model_inputs = request.model_inputs
+    for layer_name, data in input.items():
+        found_tensor = False
+        for model_input in model_inputs:
+            if model_input.get_any_name() == layer_name:
+                if PartialShape(data.shape) != model_input.get_partial_shape():
+                    raise ValueError("Input data and input layer with name {0} has different shapes: \
+                                     {1} and {2}".format(layer_name, PartialShape(data.shape), model_input.get_partial_shape()))
+                new_tensor = Tensor(data)
+                request.set_tensor(model_input.get_any_name(), new_tensor)
+                found_tensor = True
+
+        if not found_tensor:
+            raise ValueError("No input layer with name {}".format(layer_name))
+
+
+def get_request_result(request):
+    result = dict()
+    for output_node, tensor in request.results.items():
+        result[output_node.get_any_name()] = copy(tensor)
+    return result


### PR DESCRIPTION
- Обновлены скрипты инференса под OpenVINO API 2.0
-- Новые методы (`network -> model`) 
-- Теперь по умолчанию инпут картинки хранятся в формате `NHWC`, как в OpenCV. И при необходимости, если вход модели требует формат `NCHW`, картинка с помощью `transformer` конвертируется в данное представление. Это используется, чтобы удалить постоянные обратные конвертации в `io_adapter`, более того, TF модели теперь при конвертации в IR сохраняют входной формат `NHWC`
-- Добавлена поддержка `element_type` для входных данных. Чтобы входной np.array, а следовательно, и входной тензор имели тот тип данных, который требует соответствующий вход модели.