### PR TITLE
Fixes for AccuracyChecker results

### DIFF
--- a/src/accuracy_checker/result.py
+++ b/src/accuracy_checker/result.py
@@ -56,7 +56,7 @@ class Result:
             except Exception as ex:
                 print(f'ERROR! : {str(ex)}')
         else:
-            accuracies = {'N/A': ''}
+            accuracies = {'N/A': 'N/A'}
             dataset = 'N/A'
         if not accuracies:
             raise ValueError('Information about accuracy was not found in test result')


### PR DESCRIPTION
- Теперь AccuracyChecker при провалившемся тесте значение точности также записывает как `N/A`
- HTML таблица теперь генерируется с типами точности, которые присутствуют в тестах, а также указывает `Undefined` в значениях точности, если тест провалился. Кроме того, если тест провалился и метрика указана как `N/A`, отдельная строка под такую метрику создаваться не будет