### PR TITLE
tried to fix yolo models

### DIFF
--- a/src/inference/inference_async_mode.py
+++ b/src/inference/inference_async_mode.py
@@ -127,7 +127,7 @@ def cli_argument_parser():
                                  'action-recognition-encoder', 'driver-action-recognition-encoder', 'reidentification',
                                  'driver-action-recognition-decoder', 'action-recognition-decoder', 'face-detection',
                                  'mask-rcnn', 'yolo_tiny_voc', 'yolo_v2_voc', 'yolo_v2_coco', 'yolo_v2_tiny_coco',
-                                 'yolo_v3',
+                                 'yolo_v3', 'yolo_v3_tf', 'yolo_v3_tiny',
                                  ],
                         default='feedforward',
                         type=str,

--- a/src/inference/inference_sync_mode.py
+++ b/src/inference/inference_sync_mode.py
@@ -111,7 +111,7 @@ def cli_argument_parser():
                             'action-recognition-encoder', 'driver-action-recognition-encoder', 'reidentification',
                             'driver-action-recognition-decoder', 'action-recognition-decoder', 'face-detection',
                             'mask-rcnn', 'yolo_tiny_voc', 'yolo_v2_voc', 'yolo_v2_coco', 'yolo_v2_tiny_coco',
-                            'yolo_v3',
+                            'yolo_v3', 'yolo_v3_tf', 'yolo_v3_tiny',  
                         ],
                         default='feedforward',
                         type=str,
@@ -152,7 +152,7 @@ def infer_sync(compiled_model, number_iter, get_slice):
         time_infer.append(request.latency / 1000)
     if number_iter == 1:
         result = utils.get_request_result(request)
-
+    #print(f"{result},{result['conv2d_22/BiasAdd/YoloRegion'].shape}, 155, infer_sync")
     return result, time_infer
 
 

--- a/src/inference/inference_sync_mode.py
+++ b/src/inference/inference_sync_mode.py
@@ -111,7 +111,7 @@ def cli_argument_parser():
                             'action-recognition-encoder', 'driver-action-recognition-encoder', 'reidentification',
                             'driver-action-recognition-decoder', 'action-recognition-decoder', 'face-detection',
                             'mask-rcnn', 'yolo_tiny_voc', 'yolo_v2_voc', 'yolo_v2_coco', 'yolo_v2_tiny_coco',
-                            'yolo_v3', 'yolo_v3_tf', 'yolo_v3_tiny',  
+                            'yolo_v3', 'yolo_v3_tf', 'yolo_v3_tiny',
                         ],
                         default='feedforward',
                         type=str,

--- a/src/inference/inference_sync_mode.py
+++ b/src/inference/inference_sync_mode.py
@@ -152,7 +152,6 @@ def infer_sync(compiled_model, number_iter, get_slice):
         time_infer.append(request.latency / 1000)
     if number_iter == 1:
         result = utils.get_request_result(request)
-    #print(f"{result},{result['conv2d_22/BiasAdd/YoloRegion'].shape}, 155, infer_sync")
     return result, time_infer
 
 

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1841,7 +1841,7 @@ class YoloV3TFIO(YoloV3IO):
                 prediction = [confidence, class_id, bbox]
                 predictions.append(prediction)
         return predictions
-    
+
     def _get_shapes(self):
         shapes = [
             (3, 85, 38, 38),
@@ -1849,7 +1849,7 @@ class YoloV3TFIO(YoloV3IO):
             (3, 85, 76, 76),
         ]
         return shapes
-    
+
     def _get_anchors(self):
         anchors = [
             ((36, 75), (76, 55), (72, 146)),
@@ -1857,6 +1857,7 @@ class YoloV3TFIO(YoloV3IO):
             ((12, 16), (19, 36), (40, 28)),
         ]
         return anchors
+
 
 class YoloV3TinyCOCOIO(YoloV3IO):
     def __init__(self, args, io_model_wrapper, transformer):

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1649,14 +1649,11 @@ class yolo(IOAdapter):
         tx, ty, tw, th, to = detection[0:5]
         bbox_center_x = (float(cx) + self._sigmoid(tx)) * (float(w) / dx)
         bbox_center_y = (float(cy) + self._sigmoid(ty)) * (float(h) / dy)
-        print("1650!!")
         prior_width, prior_height = anchors[anchor_box_number]
-        print("1652!!")
         bbox_width = (np.exp(tw) * prior_width) * (float(w) / dx)
         bbox_height = (np.exp(th) * prior_height) * (float(h) / dy)
         confidence = self._sigmoid(to)
         scores = detection[5:]
-        #print(f"1655!! scores = {scores}, detection = {detection}")
         class_id = np.argmax(self._softmax(scores))
         best_class_score = scores[class_id]
         confidence_in_class = confidence * best_class_score
@@ -1681,21 +1678,12 @@ class yolo(IOAdapter):
             labels_map = [line.strip() for line in f]
         anchors = self._get_anchors()
         shapes = self._get_shapes()
-        # print(f"1682!! shapes = {shapes}, self._input = {self._input['input_1'].shape}")
         input_layer_name = next(iter(self._input))
         input_ = self._input[input_layer_name]
-        #frameHeight, frameWidth = input_.shape[-2:]
-        #frameHeight, frameWidth = (416, 416) yolo v3 tf
-        print(f"1685!! input_.shape[-2:] = {input_.shape[-2:]}, input_layer_name = {input_layer_name}")
         result = list(result.values())
-        print("1691!!!")
         ib, h, w, c = input_.shape
         b = result[0].shape[0]
-        #print(f"{result}, ib = {ib}, enumerate = {enumerate(result)} 1686")
-        #print(f"shapes = {shapes}")
-        #print(f"result = {len(result)}")
         images = np.ndarray(shape=(b, h, w, c))
-        print("1698!!!")
         for i in range(b):
             images[i] = input_[i % ib]
         for batch in range(ib):
@@ -1704,27 +1692,20 @@ class yolo(IOAdapter):
             orig_h, orig_w = self._original_shapes[next(iter(self._original_shapes))][batch]
             scales = {'W': orig_w / w, 'H': orig_h / h}
             for i, array_of_detections in enumerate(result):
-                #print(f"i = {i}, array_of_detections = {array_of_detections}, 1695")
                 anchors_boxes = anchors[i]
                 data = array_of_detections[batch]
                 data_shape = shapes[i]
                 dx, dy = data_shape[-2:]
-                print(f"1707!! data_shape = {data_shape}")
                 cells = data.reshape(data_shape)
-                print(f"1710!! i = {i},cells = {cells.shape} ,array_of_detections = {array_of_detections.shape}, data_shape = {data_shape},dx dy = {dx, dy},cells = {cells.shape}")
                 for cx in range(dy):
                     for cy in range(dx):
-                        #print(f"!!1707, cells[cy, cx] = {cells[:,:,cy, cx].shape}")
                         for anchor_box_number, detection in enumerate(cells[:, :, cy, cx]):
-                            #print(f"1706!!detection = {detection.shape}")
                             if detection[4] >= 0.5:
                                 prediction = self._get_cell_predictions(cx, cy, dx, dy, detection, anchor_box_number,
                                                                         h, w, anchors_boxes)
                                 if prediction is not None:
                                     predictions += prediction
-            print("1711")
             valid_detections = self.__non_max_supression(predictions, self._threshold, 0.4)
-            print("1712")
             image = self.__print_detections(valid_detections, labels_map, cv2.UMat(image),
                                             scales, (orig_w, orig_h), batch, log)
             out_img = os.path.join(os.path.dirname(__file__), f'out_yolo_detection_{batch + 1}.bmp')
@@ -1808,7 +1789,6 @@ class YoloV3IO(yolo):
         bbox_height = np.exp(th) * prior_height
         for class_id in range(80):
             confidence = detection[5 + class_id]
-            #print(f"1801!!! confidience = {confidence}, self._threshold = {self._threshold}")
             if confidence >= self._threshold:
                 bbox = [
                     float(bbox_center_x - bbox_width / 2),
@@ -1842,20 +1822,15 @@ class YoloV3TFIO(YoloV3IO):
         super().__init__(args, io_model_wrapper, transformer)
 
     def _get_cell_predictions(self, cx, cy, dx, dy, detection, anchor_box_number, h, w, anchors):
-        #print(f"1835!! frameHeight = {frameHeight}, frameWidth = {frameWidth}")
         predictions = []
         tx, ty, tw, th = detection[0:4]
         prior_width, prior_height = anchors[anchor_box_number]
-        print(f"1846!! anchors_box_number = {anchor_box_number}")
         bbox_center_x = (float(cx) + self._sigmoid(tx)) * (float(h) / dx)
         bbox_center_y = (float(cy) + self._sigmoid(ty)) * (float(w) / dy)
         bbox_width = np.exp(tw) * prior_width
         bbox_height = np.exp(th) * prior_height
-        #print(f"1841!! tx, ty, tw, th = {tx, ty, tw, th}, bbox_center_x = {bbox_center_x},bbox_center_y = {bbox_center_y} ,bbox_width = {bbox_width}, bbox_height = {bbox_height}")
-        print(f"1850!! detection = {detection.shape}")
         for class_id in range(80):
             confidence = self._sigmoid(detection[5 + class_id])
-            #print(f"1844!!! confidience = {confidence}, self._threshold = {self._threshold}")
             if confidence >= self._threshold:
                 bbox = [
                     float(bbox_center_x - bbox_width / 2),
@@ -1865,7 +1840,6 @@ class YoloV3TFIO(YoloV3IO):
                 ]
                 prediction = [confidence, class_id, bbox]
                 predictions.append(prediction)
-        print(f"1865!! predictions = {predictions}")
         return predictions
     
     def _get_shapes(self):

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1590,7 +1590,6 @@ class yolo(IOAdapter):
 
     def __non_max_supression(self, predictions, score_threshold, nms_threshold):
         predictions.sort(key=lambda prediction: prediction[0], reverse=True)
-        predictions = predictions
         valid_detections = []
         while len(predictions) > 0:
             max_detection = predictions[0]

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1590,6 +1590,7 @@ class yolo(IOAdapter):
 
     def __non_max_supression(self, predictions, score_threshold, nms_threshold):
         predictions.sort(key=lambda prediction: prediction[0], reverse=True)
+        predictions = predictions
         valid_detections = []
         while len(predictions) > 0:
             max_detection = predictions[0]
@@ -1700,7 +1701,8 @@ class yolo(IOAdapter):
                 for cx in range(dy):
                     for cy in range(dx):
                         for anchor_box_number, detection in enumerate(cells[:, :, cy, cx]):
-                            if detection[4] >= 0.5:
+                            #print(f"1703!! Detection = {detection[4]}")
+                            if self._sigmoid(detection[4]) >= 0.5:
                                 prediction = self._get_cell_predictions(cx, cy, dx, dy, detection, anchor_box_number,
                                                                         h, w, anchors_boxes)
                                 if prediction is not None:

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1844,18 +1844,19 @@ class YoloV3TFIO(YoloV3IO):
     
     def _get_shapes(self):
         shapes = [
-            (3, 85, 76, 76),
             (3, 85, 38, 38),
-            (3, 85, 19, 19)
+            (3, 85, 19, 19),
+            (3, 85, 76, 76),
         ]
         return shapes
     
     def _get_anchors(self):
         anchors = [
-            ((12, 16),(19, 36),(40, 28)),
-            ((36, 75),(76, 55),(72, 146)),
-            ((142, 110),(192, 243),(459, 401))
+            ((36, 75), (76, 55), (72, 146)),
+            ((142, 110), (192, 243), (459, 401)),
+            ((12, 16), (19, 36), (40, 28)),
         ]
+        return anchors
 
 class YoloV3TinyCOCOIO(YoloV3IO):
     def __init__(self, args, io_model_wrapper, transformer):
@@ -1864,15 +1865,13 @@ class YoloV3TinyCOCOIO(YoloV3IO):
     def _get_shapes(self):
         shapes = [
             (3, 85, 26, 26),
-            (3, 85, 13, 13)
+            (3, 85, 13, 13),
         ]
         return shapes
 
     def _get_anchors(self):
         anchors = [
             ((23, 27), (37, 58), (81, 82)),
-            ((81, 82), (135, 169), (344, 319))
+            ((81, 82), (135, 169), (344, 319)),
         ]
         return anchors
-
-

--- a/src/inference/io_adapter.py
+++ b/src/inference/io_adapter.py
@@ -1701,8 +1701,7 @@ class yolo(IOAdapter):
                 for cx in range(dy):
                     for cy in range(dx):
                         for anchor_box_number, detection in enumerate(cells[:, :, cy, cx]):
-                            #print(f"1703!! Detection = {detection[4]}")
-                            if self._sigmoid(detection[4]) >= 0.5:
+                            if detection[4] >= 0.5:
                                 prediction = self._get_cell_predictions(cx, cy, dx, dy, detection, anchor_box_number,
                                                                         h, w, anchors_boxes)
                                 if prediction is not None:

--- a/src/inference/utils.py
+++ b/src/inference/utils.py
@@ -161,6 +161,7 @@ def set_input_to_blobs(request, input_):
 
 def get_request_result(request):
     result = {}
+    #print(f"<<{request.results.items()}, [{request}], 164, utils.py>>")
     for output_node, tensor in request.results.items():
         result[output_node.get_any_name()] = copy(tensor)
     return result

--- a/src/inference/utils.py
+++ b/src/inference/utils.py
@@ -161,7 +161,6 @@ def set_input_to_blobs(request, input_):
 
 def get_request_result(request):
     result = {}
-    #print(f"<<{request.results.items()}, [{request}], 164, utils.py>>")
     for output_node, tensor in request.results.items():
         result[output_node.get_any_name()] = copy(tensor)
     return result


### PR DESCRIPTION
@FenixFly , добавил фикс, работают следующие модели:

- yolo-v1-tiny-tf
- yolo-v2-tf
- yolo-v2-tiny-tf
- yolo-v3-tf
- yolo-v3-tiny-tf

Хотел попытаться приспособить yolo 4 версий, но пока выдает ошибку обращения к NoneType элементу. Модели с суффиксами onnx, tiny-onnx довольно сильно отличаются выходными данными, поэтому, скорее всего, придётся много чего переопределить