### PR TITLE
Use implemented logging configurator

### DIFF
--- a/src/benchmark/inference_benchmark.py
+++ b/src/benchmark/inference_benchmark.py
@@ -9,7 +9,7 @@ from frameworks.framework_wrapper_registry import FrameworkWrapperRegistry
 from output import OutputHandler
 
 sys.path.append(str(Path(__file__).resolve().parents[1].joinpath('utils')))
-from logger_conf import exception_hook  # noqa: E402
+from logger_conf import configure_logger, exception_hook  # noqa: E402
 from constants import Status  # noqa: E402
 
 
@@ -95,11 +95,7 @@ def inference_benchmark(executor_type, test_list, output_handler, log,
 
 
 if __name__ == '__main__':
-    log.basicConfig(
-        format='[ %(levelname)s ] %(message)s',
-        level=log.INFO,
-        stream=sys.stdout,
-    )
+    configure_logger()
     sys.excepthook = exception_hook
 
     args = cli_argument_parser()


### PR DESCRIPTION
In [#326](https://github.com/itlab-vision/dl-benchmark/pull/326), old logging interface was replaced by another one (locally defined) in `inference_benchmark.py`. I believe that it is unnecessary to define new loggers with the same scope - better use already implemented in `utils/logger_conf.py`. Moreover, the old logger interface had colorful output (enabled by default), which makes logs more readable. I also suggest using this old logger (and also traceback hook) in other tools.
<details>
  <summary>Here are some sample launches of different loggers</summary>
Current sample log output with info, warning and error:

![nocolor](https://user-images.githubusercontent.com/126725121/226752469-06acb821-6519-4302-a88c-a1647a6ddc1f.png)

Previous version (old logger):
![color](https://user-images.githubusercontent.com/126725121/226752828-92777fc5-456c-4763-bffc-09e5f03bacc6.png)

Current PR version (reverted only logger definition):
![pr_update](https://user-images.githubusercontent.com/126725121/226752970-73228eb4-bae0-4021-9d80-4220e994b8d2.png)

</details>