### PR TITLE
add flags support in benchmark config parsers

### DIFF
--- a/src/benchmark/frameworks/mxnet/mxnet_process.py
+++ b/src/benchmark/frameworks/mxnet/mxnet_process.py
@@ -50,8 +50,8 @@ class MXNetProcess(ProcessHandler):
 
         normalize = self._test.dep_parameters.normalize
         if normalize == 'True':
-            common_params = MXNetProcess._add_optional_argument_to_cmd_line(
-                common_params, '--norm', '')
+            common_params = MXNetProcess._add_flag_to_cmd_line(
+                common_params, '--norm')
 
         mean = self._test.dep_parameters.mean
         common_params = MXNetProcess._add_optional_argument_to_cmd_line(

--- a/src/benchmark/frameworks/processes.py
+++ b/src/benchmark/frameworks/processes.py
@@ -112,6 +112,10 @@ class ProcessHandler(metaclass=abc.ABCMeta):
         return f'{command_line} {argument} {value}'
 
     @staticmethod
+    def _add_flag_to_cmd_line(command_line, flag):
+        return f'{command_line} {flag}'
+
+    @staticmethod
     def _add_env_to_cmd_line(command_line, name, value):
         return f'{name}={value} {command_line}'
 


### PR DESCRIPTION
Добавление возможности устанавливать флаги без параметров в командную строку запуска инференсов.