### PR TITLE
[MxNet] Fixed info log for input shape

### DIFF
--- a/src/inference/inference_mxnet.py
+++ b/src/inference/inference_mxnet.py
@@ -275,7 +275,7 @@ def main():
         else:
             raise ValueError('Incorrect arguments.')
 
-        log.info(f'Shape of the input layer {args.input_name}: {args.input_shape}')
+        log.info(f'Shape for input layer {args.input_name}: {args.input_shape}')
 
         log.info(f'Preparing input data {args.input}')
         io.prepare_input(net, args.input)


### PR DESCRIPTION
В бенчмаркинге инпут шейп [парсится](https://github.com/itlab-vision/dl-benchmark/blob/8030fb63d945e7df6c545ce80e72aca0fa0ec4c1/src/benchmark/frameworks/processes.py#L30) по тексту `Shape for input layer`. Выравнила поведение для `MxNet`
