### PR TITLE
fix-log-errors-windows

### DIFF
--- a/src/benchmark/frameworks/processes.py
+++ b/src/benchmark/frameworks/processes.py
@@ -13,7 +13,7 @@ class ProcessHandler(metaclass=abc.ABCMeta):
         self._executor = executor
         self._output = None
         self._status = None
-        self.timestamp = datetime.now().strftime('%d.%m.%y_%H:%M:%S')
+        self.timestamp = datetime.now().strftime('%d.%m.%y_%H-%M-%S')
         self.inference_script_root = Path(self._executor.get_path_to_inference_folder())
 
     @property
@@ -200,7 +200,7 @@ class ProcessHandler(metaclass=abc.ABCMeta):
             test_settings.append(self._test.dep_parameters.runtime)
         if hasattr(self._test.dep_parameters, 'hint') and self._test.dep_parameters.hint:
             test_settings.append(self._test.dep_parameters.hint)
-        filename = '_'.join(test_settings) + '_' + datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        filename = '_'.join(test_settings) + '_' + datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         filename += '.log'
         file_root = Path(os.getcwd())
         if not os.access(file_root, os.W_OK):

--- a/src/benchmark/frameworks/pytorch_cpp/pytorch_cpp_process.py
+++ b/src/benchmark/frameworks/pytorch_cpp/pytorch_cpp_process.py
@@ -28,7 +28,7 @@ class PyTorchCppProcess(ProcessHandler):
             raise invalid_path_exception
 
         self._report_path = executor.get_path_to_logs_folder().joinpath(
-            f'pytorch_benchmark_{test.model.name}_{datetime.now().strftime("%d.%m.%y_%H:%M:%S")}.json')
+            f'pytorch_benchmark_{test.model.name}_{datetime.now().strftime("%d.%m.%y_%H-%M-%S")}.json')
 
     @staticmethod
     def create_process(test, executor, log, cpp_benchmarks_dir):


### PR DESCRIPTION
В ОС Windows в путях нельзя ставить двоеточие, поэтому предлагаю заменить двоеточие на тире. Наши студенты многие начинают работу бенчмарка с Windows, поэтому для них это критично.