### PR TITLE
[OV] Updated performance properties

### DIFF
--- a/tests/smoke_test/configs/dl_models/mobilenet-v1-1.0-224-tf_OpenVINO_DLDT_async_mode.xml
+++ b/tests/smoke_test/configs/dl_models/mobilenet-v1-1.0-224-tf_OpenVINO_DLDT_async_mode.xml
@@ -28,4 +28,32 @@
             <StreamCount></StreamCount>
         </FrameworkDependent>
     </Test>
+    <Test>
+        <Model>
+            <Task>classification</Task>
+            <Name>mobilenet-v1-1.0-224-tf</Name>
+            <Precision>FP32</Precision>
+            <SourceFramework>tf</SourceFramework>
+            <ModelPath>../models_dir/public/mobilenet-v1-1.0-224-tf/FP32/mobilenet-v1-1.0-224-tf.xml</ModelPath>
+            <WeightsPath>../models_dir/public/mobilenet-v1-1.0-224-tf/FP32/mobilenet-v1-1.0-224-tf.bin</WeightsPath>
+        </Model>
+        <Dataset>
+            <Name>Data</Name>
+            <Path>../test_images/black_square.jpg</Path>
+        </Dataset>
+        <FrameworkIndependent>
+            <InferenceFramework>OpenVINO DLDT</InferenceFramework>
+            <BatchSize>1</BatchSize>
+            <Device>CPU</Device>
+            <IterationCount>5</IterationCount>
+            <TestTimeLimit>1</TestTimeLimit>
+        </FrameworkIndependent>
+        <FrameworkDependent>
+            <Mode>async</Mode>
+            <Extension></Extension>
+            <AsyncRequestCount>1</AsyncRequestCount>
+            <ThreadCount></ThreadCount>
+            <StreamCount>2</StreamCount>
+        </FrameworkDependent>
+    </Test>
 </Tests>

--- a/tests/smoke_test/configs/dl_models/mobilenet-v1-1.0-224-tf_OpenVINO_DLDT_sync_mode.xml
+++ b/tests/smoke_test/configs/dl_models/mobilenet-v1-1.0-224-tf_OpenVINO_DLDT_sync_mode.xml
@@ -28,4 +28,32 @@
             <StreamCount></StreamCount>
         </FrameworkDependent>
     </Test>
+    <Test>
+        <Model>
+            <Task>classification</Task>
+            <Name>mobilenet-v1-1.0-224-tf</Name>
+            <Precision>FP32</Precision>
+            <SourceFramework>tf</SourceFramework>
+            <ModelPath>../models_dir/public/mobilenet-v1-1.0-224-tf/FP32/mobilenet-v1-1.0-224-tf.xml</ModelPath>
+            <WeightsPath>../models_dir/public/mobilenet-v1-1.0-224-tf/FP32/mobilenet-v1-1.0-224-tf.bin</WeightsPath>
+        </Model>
+        <Dataset>
+            <Name>Data</Name>
+            <Path>../test_images/black_square.jpg</Path>
+        </Dataset>
+        <FrameworkIndependent>
+            <InferenceFramework>OpenVINO DLDT</InferenceFramework>
+            <BatchSize>1</BatchSize>
+            <Device>CPU</Device>
+            <IterationCount>5</IterationCount>
+            <TestTimeLimit>1</TestTimeLimit>
+        </FrameworkIndependent>
+        <FrameworkDependent>
+            <Mode>sync</Mode>
+            <Extension></Extension>
+            <AsyncRequestCount></AsyncRequestCount>
+            <ThreadCount>2</ThreadCount>
+            <StreamCount></StreamCount>
+        </FrameworkDependent>
+    </Test>
 </Tests>


### PR DESCRIPTION
### Details:
- Properties `CPU_THREADS_NUM` and `CPU_THROUGHPUT_STREAMS` are deprecated. Now we have to use `props.inference_num_threads` and `props.num_streams`. The [link](https://docs.openvino.ai/2024/openvino-workflow/running-inference/inference-devices-and-modes/cpu-device/performance-hint-and-thread-scheduling.html) to the documentation.
- Added smoke tests to validate the case when the user manually sets thread count and stream count